### PR TITLE
Being slightly more explicit about scales.

### DIFF
--- a/astronum_2018/astronum-xrb.tex
+++ b/astronum_2018/astronum-xrb.tex
@@ -115,13 +115,13 @@ See~\cite{galloway:2017} for a recent review of XRBs.
 
 Simulations of XRBs can help us to understand the observations, but
 many technical challenges remain.  The primary difficulties are simply
-the range of length and timescales involved.  At the largest scale,
+the range of length and timescales involved.  At the largest lengthscale,
 the neutron star radius is 10~km and the Rossby lengthscale, where rotation
 and lateral pressure gradients balance, is $\sim
 1$~km~\cite{SPIT_ETAL02}.  At the smallest scales, a conductive He
 flame has a thickness of 10s of centimeters~\cite{Timmes00} and the
 pressure scale height of the fuel layer is meters.  To capture the
-rise of the XRB\MarginPar{Define rise?}, we would need to model seconds, but the flame itself
+rise timescale of the XRB, we would need to model seconds, but the flame itself
 is subsonic, so long timescale evolution is difficult.
 
 Present and past simulations of XRBs employ a variety of


### PR DESCRIPTION
Suggestion on explicitly linking timescales to rise, to avoid needing to get into definitions.