### PR TITLE
Remove explicit References section.

### DIFF
--- a/astronum_2018/astronum-xrb.tex
+++ b/astronum_2018/astronum-xrb.tex
@@ -305,12 +305,12 @@ acting along the flame front may cause instabilities that can affect the flame
 propagation.
 With our current simulation methodology,
 a 3D version of this calculation is estimated to require 10M node-hours
-or more---this is about the size of an annualallocation.
+or more---this is about the size of an annual allocation.
 %Additionally, this is still with the boosted flame, but we expect that once the flame is developed, the boosting will not be as critical, due to hydrodynamic effects.
 This simulation covers less than
 1\% of the neutron star surface, so a fully resolved calculation of
 burning over the entire neutron star is out of reach: a naive scaling
-calculation suggest that 15 years of Moore's Law improvements are required.
+calculation suggests that 15 years of Moore's Law improvements are required.
 %
 % The calculation above is
 % log_2 [ (4 pi 10^2) / (1.23^2) ] * 1.5
@@ -514,7 +514,7 @@ This research has made use of NASA's Astrophysics Data System
 Bibliographic Services.
 
 
-\section*{References}
+%\section*{References}
 
 \bibliographystyle{iopart-num}
 \bibliography{ws}


### PR DESCRIPTION
As the bibliography command puts one in on my system, so it duplicates the "References" section title (?).

Also a couple of tiny typos.